### PR TITLE
Fixed threshold regular expression to accept more than 1 digit

### DIFF
--- a/MSTest.Console.Extended.UnitTests/ConsoleArgumentsProviderTests/ConsoleArgumentsProvider_Constructor_Should.cs
+++ b/MSTest.Console.Extended.UnitTests/ConsoleArgumentsProviderTests/ConsoleArgumentsProvider_Constructor_Should.cs
@@ -288,10 +288,10 @@ namespace MSTest.Console.Extended.UnitTests.ConsoleArgumentsProviderTests
                 "/retriesCount:3",
                 "/deleteOldResultsFiles:true",
                 @"/newResultsfile:C:\ResultsNew.trx",
-                "/threshold:5"
+                "/threshold:10"
             };
             var consoleArgumentsProvider = new ConsoleArgumentsProvider(args);
-            Assert.AreEqual<int>(5, consoleArgumentsProvider.FailedTestsThreshold);
+            Assert.AreEqual<int>(10, consoleArgumentsProvider.FailedTestsThreshold);
         }
 
         [TestMethod]

--- a/MSTest.Console.Extended/Infrastructure/ConsoleArgumentsProvider.cs
+++ b/MSTest.Console.Extended/Infrastructure/ConsoleArgumentsProvider.cs
@@ -12,7 +12,7 @@ namespace MSTest.Console.Extended.Infrastructure
         private readonly string testResultFilePathRegexPattern = @".*resultsfile:(?<ResultsFilePath>[1-9A-Za-z\\:._]{1,})";
         private readonly string testNewResultFilePathRegexPattern = @".*(?<NewResultsFilePathArgument>/newResultsfile:(?<NewResultsFilePath>[1-9A-Za-z\\:._]{1,}))";
         private readonly string retriesRegexPattern = @".*(?<RetriesArgument>/retriesCount:(?<RetriesCount>[0-9]{1})).*";
-        private readonly string failedTestsThresholdRegexPattern = @".*(?<ThresholdArgument>/threshold:(?<ThresholdCount>[0-9]{1})).*";
+        private readonly string failedTestsThresholdRegexPattern = @".*(?<ThresholdArgument>/threshold:(?<ThresholdCount>[0-9]{1,3})).*";
         private readonly string deleteOldFilesRegexPattern = @".*(?<DeleteOldFilesArgument>/deleteOldResultsFiles:(?<DeleteOldFilesValue>[a-zA-Z]{4,5})).*";
         private readonly string argumentRegexPattern = @".*/(?<ArgumentName>[a-zA-Z]{1,}):(?<ArgumentValue>.*)";
 


### PR DESCRIPTION
This is to fix your issue with threshold value only accepting 1 digit. it now accepts minimum of 1 and maximum of 3